### PR TITLE
Add /get request handler; fix /document request handler.

### DIFF
--- a/test_core/conf/solrconfig.xml
+++ b/test_core/conf/solrconfig.xml
@@ -445,7 +445,24 @@
         <str name="q.alt">*:*</str>
         <str name="facet.mincount">1</str>
         &select_edismax;
-    </lst> 
+    </lst>
+  </requestHandler>
+
+  <requestHandler name="/get" class="solr.RealTimeGetHandler">
+    <lst name="defaults">
+      <str name="omitHeader">true</str>
+      <str name="echoParams">explicit</str>
+      <str name="fl">*</str>
+    </lst>
+  </requestHandler>
+
+  <requestHandler name="/document" class="solr.SearchHandler" >
+    <lst name="defaults">
+      <str name="echoParams">explicit</str>
+      <str name="fl">*</str>
+      <str name="rows">1</str>
+      <str name="q">{!term f=id v=$id}</str> <!-- use id=666 instead of q=id:666 -->
+    </lst>
   </requestHandler>
 
   <!-- A request handler that returns indented JSON by default -->
@@ -565,15 +582,6 @@
     <arr name="components">
       <str>terms</str>
     </arr>
-  </requestHandler>
-
-  <requestHandler name="document" class="solr.SearchHandler" >
-    <lst name="defaults">
-      <str name="echoParams">all</str>
-      <str name="fl">*</str>
-      <str name="rows">1</str>
-      <str name="q">{!term f=id v=$id}</str> <!-- use id=666 instead of q=id:666 -->
-    </lst>
   </requestHandler>
 
 </config>


### PR DESCRIPTION
This adds a /get requestHandler if we want to use Solr RealTimeGetHandler for document requests. It also fixes the name of the /document requestHandler so Blacklight can use it without having handleSelect set to true. We can now configure TRLN Argon to use either /document or /get for document requests.